### PR TITLE
Update Gradle to 8.14.3 and implement version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
-    kotlin("jvm") version "2.0.21"
-    kotlin("plugin.spring") version "2.0.21"
-    id("org.springframework.boot") version "3.5.3"
-    id("io.spring.dependency-management") version "1.1.7"
-    id("com.netflix.dgs.codegen") version "7.0.3"
-    id("org.graalvm.buildtools.native") version "0.10.6"
-    id("gg.jte.gradle") version "3.1.16"
-    id("io.gitlab.arturbosch.detekt") version "1.23.8"
-    id("org.jlleitschuh.gradle.ktlint") version "13.0.0"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+    alias(libs.plugins.netflix.dgs.codegen)
+    alias(libs.plugins.graalvm.native)
+    alias(libs.plugins.jte.gradle)
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktlint)
 }
 
 group = "dev.fzymgc.bootstrap.graphql-model-mutate"
@@ -29,47 +29,53 @@ repositories {
     mavenCentral()
 }
 
-extra["netflixDgsVersion"] = "10.2.1"
-extra["springCloudVersion"] = "2025.0.0"
-
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
-    implementation("org.springframework.boot:spring-boot-starter-data-cassandra")
-    implementation("org.springframework.boot:spring-boot-starter-data-cassandra-reactive")
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter")
-    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
-    implementation("gg.jte:jte-spring-boot-starter-3:3.1.16")
-    implementation("io.micrometer:micrometer-tracing-bridge-brave")
-    implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
-    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
-    implementation("org.jspecify:jspecify:1.0.0")
-    compileOnly("org.projectlombok:lombok")
-    developmentOnly("org.springframework.boot:spring-boot-devtools")
-    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
-    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
-    annotationProcessor("org.projectlombok:lombok")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.springframework.boot:spring-boot-testcontainers")
-    testImplementation("com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test")
-    testImplementation("io.projectreactor:reactor-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
-    testImplementation("org.springframework.security:spring-security-test")
-    testImplementation("org.testcontainers:cassandra")
-    testImplementation("org.testcontainers:junit-jupiter")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    // Spring Boot bundles
+    implementation(libs.bundles.spring.boot.web)
+    implementation(libs.bundles.spring.boot.data)
+
+    // Individual Spring dependencies
+    implementation(libs.spring.cloud.starter.circuitbreaker.reactor.resilience4j)
+
+    // Jackson
+    implementation(libs.jackson.module.kotlin)
+
+    // Netflix DGS
+    implementation(libs.graphql.dgs.spring.graphql.starter)
+
+    // JTE
+    implementation(libs.jte.spring.boot.starter)
+
+    // Micrometer
+    implementation(libs.micrometer.tracing.bridge.brave)
+    runtimeOnly(libs.micrometer.registry.prometheus)
+
+    // Kotlin
+    implementation(libs.kotlin.reflect)
+    implementation(libs.bundles.kotlin.reactive)
+
+    // Other libraries
+    implementation(libs.jspecify)
+    compileOnly(libs.lombok)
+
+    // Development dependencies
+    developmentOnly(libs.spring.boot.devtools)
+    developmentOnly(libs.spring.boot.docker.compose)
+
+    // Annotation processors
+    annotationProcessor(libs.spring.boot.configuration.processor)
+    annotationProcessor(libs.lombok)
+
+    // Test dependencies
+    testImplementation(libs.bundles.testing)
+    testImplementation(libs.graphql.dgs.spring.graphql.starter.test)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 dependencyManagement {
     imports {
-        mavenBom("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:${property("netflixDgsVersion")}")
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+        mavenBom("com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:${libs.versions.netflixDgs.get()}")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${libs.versions.springCloudVersion.get()}")
     }
 }
 
@@ -108,7 +114,7 @@ detekt {
 
 // Ktlint configuration
 ktlint {
-    version.set("1.5.0")
+    version.set(libs.versions.ktlintCore.get())
     android.set(false)
     outputToConsole.set(true)
     outputColorName.set("RED")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,130 @@
+[versions]
+# Kotlin
+kotlin = "2.0.21"
+
+# Spring
+springBoot = "3.5.3"
+springCloudVersion = "2025.0.0"
+springDependencyManagement = "1.1.7"
+
+# Netflix DGS
+netflixDgs = "10.2.1"
+netflixDgsCodegen = "7.0.3"
+
+# GraalVM
+graalvmNative = "0.10.6"
+
+# JTE
+jte = "3.1.16"
+
+# Code Quality
+detekt = "1.23.8"
+ktlint = "13.0.0"
+ktlintCore = "1.5.0"
+
+# Libraries
+jackson = "2.18.2"
+micrometer = "1.15.0"
+jspecify = "1.0.0"
+lombok = "1.18.36"
+projectReactor = "3.7.1"
+kotlinxCoroutines = "1.9.0"
+
+# Testing
+testcontainers = "1.20.5"
+junit = "5.11.5"
+
+[libraries]
+# Spring Boot Starters
+spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+spring-boot-starter-data-cassandra = { module = "org.springframework.boot:spring-boot-starter-data-cassandra" }
+spring-boot-starter-data-cassandra-reactive = { module = "org.springframework.boot:spring-boot-starter-data-cassandra-reactive" }
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
+spring-boot-starter-webflux = { module = "org.springframework.boot:spring-boot-starter-webflux" }
+spring-boot-starter-thymeleaf = { module = "org.springframework.boot:spring-boot-starter-thymeleaf" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
+spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools" }
+spring-boot-docker-compose = { module = "org.springframework.boot:spring-boot-docker-compose" }
+spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
+
+# Spring Cloud
+spring-cloud-starter-circuitbreaker-reactor-resilience4j = { module = "org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j" }
+
+# Spring Security
+spring-security-test = { module = "org.springframework.security:spring-security-test" }
+
+# Jackson
+jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin" }
+
+# Netflix DGS
+graphql-dgs-spring-graphql-starter = { module = "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter" }
+graphql-dgs-spring-graphql-starter-test = { module = "com.netflix.graphql.dgs:graphql-dgs-spring-graphql-starter-test" }
+
+# JTE
+jte-spring-boot-starter = { module = "gg.jte:jte-spring-boot-starter-3", version.ref = "jte" }
+
+# Micrometer
+micrometer-tracing-bridge-brave = { module = "io.micrometer:micrometer-tracing-bridge-brave" }
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
+
+# Reactor
+reactor-kotlin-extensions = { module = "io.projectreactor.kotlin:reactor-kotlin-extensions" }
+reactor-test = { module = "io.projectreactor:reactor-test" }
+
+# Kotlin
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
+
+# Other Libraries
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
+lombok = { module = "org.projectlombok:lombok" }
+
+# Testcontainers
+testcontainers-cassandra = { module = "org.testcontainers:cassandra" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter" }
+
+# JUnit
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+
+[bundles]
+spring-boot-web = [
+    "spring-boot-starter-actuator",
+    "spring-boot-starter-webflux",
+    "spring-boot-starter-security",
+    "spring-boot-starter-thymeleaf"
+]
+
+spring-boot-data = [
+    "spring-boot-starter-data-cassandra",
+    "spring-boot-starter-data-cassandra-reactive"
+]
+
+kotlin-reactive = [
+    "reactor-kotlin-extensions",
+    "kotlinx-coroutines-reactor"
+]
+
+testing = [
+    "spring-boot-starter-test",
+    "spring-boot-testcontainers",
+    "reactor-test",
+    "kotlin-test-junit5",
+    "kotlinx-coroutines-test",
+    "spring-security-test",
+    "testcontainers-cassandra",
+    "testcontainers-junit-jupiter"
+]
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "springDependencyManagement" }
+netflix-dgs-codegen = { id = "com.netflix.dgs.codegen", version.ref = "netflixDgsCodegen" }
+graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvmNative" }
+jte-gradle = { id = "gg.jte.gradle", version.ref = "jte" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
## Summary
- Upgraded Gradle wrapper from 8.10.1 to 8.14.3 (latest stable release)
- Implemented Gradle version catalog for centralized dependency management
- Organized dependencies into logical groups with bundles

## Changes
- Created `gradle/libs.versions.toml` with all dependency versions
- Updated `build.gradle.kts` to use version catalog references
- Organized dependencies with bundles:
  - `spring-boot-web`: Web-related Spring Boot starters
  - `spring-boot-data`: Data access starters
  - `kotlin-reactive`: Kotlin reactive extensions
  - `testing`: All test dependencies

## Benefits
- Centralized version management across the project
- Better dependency updates via Renovate
- Type-safe dependency references
- Cleaner and more maintainable build files

## Test plan
- [x] Build passes with `./gradlew build`
- [x] All tests pass
- [x] Ktlint checks pass
- [x] Detekt analysis passes
- [x] No regressions in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)