### PR TITLE
Move renovate.json to .github directory and update timezone

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
     ":dependencyDashboard",
     ":semanticCommitTypeAll(chore)"
   ],
-  "timezone": "Europe/Amsterdam",
+  "timezone": "US/Eastern",
   "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
   "labels": ["dependencies", "renovate"],
   "separateMajorMinor": true,


### PR DESCRIPTION
## Summary
- Moved renovate.json to .github directory for better organization
- Updated timezone from Europe/Amsterdam to US/Eastern

## Changes
1. **File relocation**: `renovate.json` → `.github/renovate.json`
   - Renovate supports configuration files in the .github directory
   - Keeps repository root cleaner
   - Groups GitHub-related configs together

2. **Timezone update**: `Europe/Amsterdam` → `US/Eastern`
   - Aligns with US Eastern timezone
   - Schedule remains the same (10pm-5am weekdays, weekends)

## Test plan
- [x] Verify file moved correctly with git
- [x] Confirm timezone value is valid
- [ ] Renovate will detect config in new location after merge
- [ ] Schedule will use US/Eastern timezone for update windows

🤖 Generated with [Claude Code](https://claude.ai/code)